### PR TITLE
Sync with upstream thoughtbot/laptop

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## 2025-07-09
+
+* Removed deprecated homebrew/services tap
+
 ## 2025-06-25
 
 * asdf is now updated if it is already installed and asdf commands were updated

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## 2025-06-25
+
+* asdf is now updated if it is already installed and asdf commands were updated
+  to work with latest versions.
+
 ## 2024-09-24
 
 * Support for macOS Sequoia

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2022 thoughtbot, inc.
+Copyright (c) 2011-2025 thoughtbot, inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ You can use the free and open source emulator [UTM].
 
 Tip: Make a fresh virtual machine with the installation of macOS completed and
 your user created and first launch complete. Then duplicate that machine to test
-the script each time on a fresh install thats ready to go.
+the script each time on a fresh install that's ready to go.
 
 [UTM]: https://mac.getutm.app
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ macOS tools:
 
 Unix tools:
 
+* [fzf][] for better command history searching
 * [Universal Ctags] for indexing files for vim tab completion
 * [Git] for version control
 * [OpenSSL] for Transport Layer Security (TLS)
@@ -80,6 +81,7 @@ Unix tools:
 * [Watchman] for watching for filesystem events
 * [Zsh] as your shell
 
+[fzf]: https://github.com/junegunn/fzf
 [Universal Ctags]: https://ctags.io/
 [Git]: https://git-scm.com/
 [OpenSSL]: https://www.openssl.org/

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ you agree to abide by the thoughtbot [code of conduct].
 Edit the `mac` file.
 Document in the `README.md` file.
 Update the `CHANGELOG`.
-Follow shell style guidelines by using [ShellCheck] and [Syntastic].
+Follow shell style guidelines by using [ShellCheck] and [ALE] or deprecated [Syntastic].
 
 ```sh
 brew install shellcheck
@@ -209,6 +209,8 @@ brew install shellcheck
 
 [ShellCheck]: http://www.shellcheck.net/about.html
 [Syntastic]: https://github.com/scrooloose/syntastic
+[ALE]: https://github.com/dense-analysis/ale
+
 
 ### Testing your changes
 

--- a/README.md
+++ b/README.md
@@ -247,5 +247,4 @@ We are [available for hire][hire].
 [community]: https://thoughtbot.com/community?utm_source=github
 [hire]: https://thoughtbot.com/hire-us?utm_source=github
 
-
 <!-- END /templates/footer.md -->

--- a/mac
+++ b/mac
@@ -121,7 +121,6 @@ fancy_echo "Updating Homebrew formulae ..."
 brew update --force # https://github.com/Homebrew/brew/issues/1151
 brew bundle --file=- <<EOF
 tap "thoughtbot/formulae"
-tap "homebrew/services"
 tap "heroku/brew"
 
 # Unix

--- a/mac
+++ b/mac
@@ -168,6 +168,8 @@ fancy_echo "Configuring asdf version manager ..."
 if [ ! -d "$HOME/.asdf" ]; then
   brew install asdf
   append_to_zshrc "source $(brew --prefix asdf)/libexec/asdf.sh" 1
+else
+  brew upgrade asdf
 fi
 
 alias install_asdf_plugin=add_or_update_asdf_plugin
@@ -175,10 +177,10 @@ add_or_update_asdf_plugin() {
   local name="$1"
   local url="$2"
 
-  if ! asdf plugin-list | grep -Fq "$name"; then
-    asdf plugin-add "$name" "$url"
+  if ! asdf plugin list | grep -Fq "$name"; then
+    asdf plugin add "$name" "$url"
   else
-    asdf plugin-update "$name"
+    asdf plugin update "$name"
   fi
 }
 
@@ -190,11 +192,11 @@ add_or_update_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
 install_asdf_language() {
   local language="$1"
   local version
-  version="$(asdf list-all "$language" | grep -v "[a-z]" | tail -1)"
+  version="$(asdf list all "$language" | grep -v "[a-z]" | tr -s '\n' | tail -1)"
 
   if ! asdf list "$language" | grep -Fq "$version"; then
     asdf install "$language" "$version"
-    asdf global "$language" "$version"
+    asdf set --home "$language" "$version"
   fi
 }
 

--- a/mac
+++ b/mac
@@ -125,6 +125,7 @@ tap "heroku/brew"
 
 # Unix
 brew "universal-ctags"
+brew "fzf"
 brew "git"
 brew "openssl"
 brew "rcm"


### PR DESCRIPTION
## Summary

- Merges latest upstream changes from thoughtbot/laptop (commits through `1d3f29f`)
- Resolves conflicts preserving personal customizations

## Changes from upstream

- Add `fzf` for better command history searching
- Remove deprecated `homebrew/services` tap (now integrated into brew)
- Update asdf CLI to new command syntax (`plugin list/add/update`, `list all`)
- Upgrade asdf when already installed (`brew upgrade asdf`)
- Use `asdf set --home` instead of deprecated `asdf global`

## Conflict resolutions

- Kept our Brewfile additions; dropped `thoughtbot/formulae` tap and `universal-ctags` (both intentionally removed in our config)
- Added upstream's `fzf` entry to README Unix tools section; omitted `Universal Ctags` since we don't install it

🤖 Generated with [Claude Code](https://claude.com/claude-code)